### PR TITLE
fixed hub links to bootstrap metro

### DIFF
--- a/hub.html
+++ b/hub.html
@@ -177,7 +177,7 @@
    
                   <h2>Bootstrap Metro</h2>
    
-                  <a class="tile wide imagetext bg-color-blue" href="./bootstrap-scaffolding.html">
+                  <a class="tile wide imagetext bg-color-blue" href="./scaffolding.html">
                      <div class="image-wrapper">
                         <img src="content/img/My Apps.png" />
                      </div>
@@ -189,7 +189,7 @@
                      <span class="app-label">SCAFFOLDING</span>
                   </a>
    
-                  <a class="tile wide imagetext bg-color-blueDark" href="./bootstrap-base-css.html">
+                  <a class="tile wide imagetext bg-color-blueDark" href="./base-css.html">
                      <div class="image-wrapper">
                         <img src="content/img/Coding app.png" />
                      </div>
@@ -202,14 +202,14 @@
                      <span class="app-label">BASE CSS</span>
                   </a>
    
-                  <a class="tile app bg-color-orange" href="./bootstrap-components.html">
+                  <a class="tile app bg-color-orange" href="./components.html">
                      <div class="image-wrapper">
                         <img src="content/img/RegEdit.png" alt="" />
                      </div>
                      <span class="app-label">COMPONENTS</span>
                   </a>
    
-                  <a class="tile app bg-color-red" href="./bootstrap-javascript.html">
+                  <a class="tile app bg-color-red" href="./javascript.html">
                      <div class="image-wrapper">
                         <img src="content/img/Devices.png" alt="" />
                      </div>


### PR DESCRIPTION
On hub.html if you clicked on any link from "bootstrap metro" you were getting 404 on every link.
