### PR TITLE
Added toggleSection function in bootmetro-charms.js

### DIFF
--- a/src/assets/js/bootmetro-charms.js
+++ b/src/assets/js/bootmetro-charms.js
@@ -75,6 +75,14 @@
       close: function(){
          $(this.element).removeClass('in');
          return false;
+      },
+
+      toggleSection: function(sectionId, width){
+         if ($(this.element).hasClass('in')){
+            this.close();
+         }else{
+            this.showSection(sectionId, width);
+         }
       }//,
 //
 //      togglePin: function () {


### PR DESCRIPTION
Added toggleSection function in bootmetro-charms.js to show or close charms section.

Usage as follow :
  $("#btn-home").click(function (e) {
      e.preventDefault();
      $('#charms').charms('toggleSection', 'theme-charms-section');
  });
